### PR TITLE
German translation for the fixer's manifesto

### DIFF
--- a/de/manifesto.md
+++ b/de/manifesto.md
@@ -1,0 +1,29 @@
+﻿Das Manifest der "Reparierer"
+=============================
+
+**1. Wenn es kaputt ist, repariere es.** Weil das tägliche, praktische Lösen von Problemen die schönste Form der Kreativität ist, die es gibt.
+
+**2. Wenn es nicht kaputt ist, verbessere es.** Eine kleine, clevere Optimierung kann die Funktion von etwas für die kommenden Jahre verbessern.
+
+**3. Verlängere das Leben deiner Produkte.** Wenn wir die Lebensdauer unseres Krams verdoppeln, halbieren wir die Müllhalden.
+
+**4. Reparieren bedeutet Freiheit und Unabhängigkeit.** Wenn du Dinge reparierst, musst du dir keine Sorgen um die Abnutzung machen. Nichts bleibt neu, also vergiss Perfektion.
+
+**5. Widerstehe Trends und nutzlosen Verbesserungen.** Sie fördern die Wegwerfkultur.
+
+**6. Lass dich nicht von Firmen als passiver Konsument behandeln.** Jedes Mal, wenn wir Geld ausgeben stimmen wir auch über die Produkte ab, die Erfolg haben sollen. Kaufe Produkte, die repariert werden können.
+
+**7. Eine reparierte Sache ist etwas Schönes.** Jede Reparatur, egal ob kunstvoll oder improvisiert, erzählt eine Geschichte.
+
+**8. Wenn du eine Idee hast, fange klein an und mache es gut.** Wenn es richtig ist, wird es wachsen.
+
+**9. Pflege deine Neugierde. Probiere Dinge, die du noch nie zuvor gemacht hast.** Es ist gut für dein Gehirn und deine Seele. Habe keine Angst zu scheitern - es macht den Erfolg nur umso süßer.
+
+**10. Alle Menschen sind unterschiedlich. Produkte sollten es auch sein.** Alles kann verbessert oder individuell angepasst werden.
+
+**11. Die Lebensdauer eines Produktes ist eine Entscheidung, keine Eigenschaft.** Kunststoffe sind nicht böse, aber wir setzen sie falsch ein. Behandele sie mit Respekt.
+
+**12. Lass andere an deinen Idee, deinem Enthusiasmus und deinen Fähigkeiten teilhaben.** Wenn du die Freude am Reparieren entdeckt hast, gib sie weiter. Es ist ein Talent.
+
+Von den Erfindern von [sugru](https://sugru.com).
+Inspiriert durch das Manifest von [Platform 21](http://www.platform21.nl), [ifixit](http://www.ifixit.com/), [Holstee](http://shop.holstee.com/pages/about) und den [Cult of Done](http://www.brepettis.com/blog/2009/3/3/the-cult-of-done-manifesto.html).


### PR DESCRIPTION
Provided a German translation for the fixers manifesto. The main problem
with the translation is that the word "fixer" cannot be easily
translated into German directly. A literal translation is not possible
because the German word "Fixer" means a drug addict. As there is no
German noun for a person reparing things, I forged a term from the
German verb for repairing "reparieren" und the suffix for persons doing
sometihing "er".
